### PR TITLE
Fix word search on mobile

### DIFF
--- a/src/WordSearch.jsx
+++ b/src/WordSearch.jsx
@@ -144,11 +144,11 @@ export default function WordSearch({ onBack }) {
     }
   };
 
-  const handleMouseDown = (row, col) => {
+  const handlePointerDown = (row, col) => {
     setStartCell([row, col]);
   };
 
-  const handleMouseUp = (row, col) => {
+  const handlePointerUp = (row, col) => {
     if (!startCell) return;
     const [r0, c0] = startCell;
     const dr = Math.sign(row - r0);
@@ -238,8 +238,8 @@ export default function WordSearch({ onBack }) {
                   return (
                     <td
                       key={colIdx}
-                      onMouseDown={() => handleMouseDown(rowIdx, colIdx)}
-                      onMouseUp={() => handleMouseUp(rowIdx, colIdx)}
+                      onPointerDown={() => handlePointerDown(rowIdx, colIdx)}
+                      onPointerUp={() => handlePointerUp(rowIdx, colIdx)}
                       className="board-cell"
                       style={{ background: cellColor ? cellColor : "#fff" }}
                     >

--- a/src/index.css
+++ b/src/index.css
@@ -340,6 +340,7 @@ button:focus-visible {
   border: 1px solid #999;
   text-align: center;
   user-select: none;
+  touch-action: none;
   font-weight: bold;
   font-size: 16px;
 }


### PR DESCRIPTION
## Summary
- update WordSearch to use pointer events for selecting cells
- disable default touch behavior on game board cells

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68650d7b6e208320943441c4542c2d36